### PR TITLE
Fix ö in seconduniversityname

### DIFF
--- a/chalmers-thesis.cls
+++ b/chalmers-thesis.cls
@@ -209,7 +209,7 @@
    \def\cityname{G\"oteborg}%
    \def\telephonename{Telefon}%
    \def\universityname{Chalmers tekniska h\"ogskola}%
-   \def\seconduniversityname{Göteborgs universitet}%
+   \def\seconduniversityname{G\"oteborgs universitet}%
    \def\covername{Omslag}%
    \def\acknowledgementsname{Tacks\"agelse}%
    \def\keywordsname{Nyckelord}%


### PR DESCRIPTION
The ö disappears in the generated PDF (using pdflatex).
